### PR TITLE
use function_arguments for naming generated function inputs

### DIFF
--- a/aipolabs/meta_functions/_aipolabs_execute_function.py
+++ b/aipolabs/meta_functions/_aipolabs_execute_function.py
@@ -21,21 +21,21 @@ SCHEMA = {
                     "type": "string",
                     "description": f"The name of the function to execute, which is retrieved from the {AipolabsGetFunctionDefinition.NAME} function.",
                 },
-                "function_parameters": {
+                "function_arguments": {
                     "type": "object",
                     "description": "A dictionary containing key-value pairs of input parameters required by the specified function. The parameter names and types must match those defined in the function definition previously retrieved. If the function requires no parameters, provide an empty object.",
                     "additionalProperties": True,
                 },
             },
-            "required": ["function_name", "function_parameters"],
+            "required": ["function_name", "function_arguments"],
             "additionalProperties": False,
         },
     },
 }
 
 
-def wrap_function_parameters_if_not_present(obj: dict) -> dict:
-    if "function_parameters" not in obj:
+def wrap_function_arguments_if_not_present(obj: dict) -> dict:
+    if "function_arguments" not in obj:
         # Create a copy of the input dict
         processed_obj = obj.copy()
         if "function_name" not in processed_obj:
@@ -45,7 +45,7 @@ def wrap_function_parameters_if_not_present(obj: dict) -> dict:
         # Create new dict with correct structure
         processed_obj = {
             "function_name": function_name,
-            "function_parameters": processed_obj,  # All remaining fields go here
+            "function_arguments": processed_obj,  # All remaining fields go here
         }
         return processed_obj
     return obj

--- a/aipolabs/resource/apps.py
+++ b/aipolabs/resource/apps.py
@@ -19,7 +19,7 @@ class AppsResource(APIResource):
         limit: int | None = None,
         offset: int | None = None,
     ) -> list[App]:
-        """Searches for apps using the provided parameters.
+        """Search for apps.
 
         Args:
             intent: search results will be sorted by relevance to this intent.

--- a/aipolabs/resource/functions.py
+++ b/aipolabs/resource/functions.py
@@ -29,7 +29,7 @@ class FunctionsResource(APIResource):
         limit: int | None = None,
         offset: int | None = None,
     ) -> list[Function]:
-        """Searches for functions using the provided parameters.
+        """Searches for functions.
 
         Args:
             app_names: List of app names to filter functions by.
@@ -99,13 +99,13 @@ class FunctionsResource(APIResource):
 
     @retry(**retry_config)
     def execute(
-        self, function_name: str, function_parameters: dict, linked_account_owner_id: str
+        self, function_name: str, function_arguments: dict, linked_account_owner_id: str
     ) -> FunctionExecutionResult:
-        """Executes a Aipolabs indexed function with the provided parameters.
+        """Executes a Aipolabs indexed function with the provided arguments.
 
         Args:
             function_name: Name of the function to execute.
-            function_parameters: Dictionary containing the input parameters for the function.
+            function_arguments: Dictionary containing the input arguments for the function.
             linked_account_owner_id: to specify with credentials of which linked account the
             function should be executed.
         Returns:
@@ -116,13 +116,13 @@ class FunctionsResource(APIResource):
         """
         validated_params = FunctionExecutionParams(
             function_name=function_name,
-            function_parameters=function_parameters,
+            function_arguments=function_arguments,
             linked_account_owner_id=linked_account_owner_id,
         )
 
         logger.info(f"Executing function with: {validated_params.model_dump()}")
         request_body = {
-            "function_input": validated_params.function_parameters,
+            "function_input": validated_params.function_arguments,
         }
         response = self._httpx_client.post(
             f"functions/{validated_params.function_name}/execute",

--- a/aipolabs/types/functions.py
+++ b/aipolabs/types/functions.py
@@ -26,15 +26,15 @@ class FunctionExecutionParams(BaseModel):
     The function requires two key parameters:
     1. function_name: The name of the function to execute, which is the function name of the function that is
     retrieved using the AIPOLABS_GET_FUNCTION_DEFINITION meta function.
-    2. function_parameters: A dictionary containing all input parameters required to execute
-    the specified function. These parameters are also provided by the function definition
-    retrieved using the AIPOLABS_GET_FUNCTION_DEFINITION meta function. If a function does not require parameters, an empty dictionary should be provided.
+    2. function_arguments: A dictionary containing all input arguments required to execute
+    the specified function. These arguments are also provided by the function definition
+    retrieved using the AIPOLABS_GET_FUNCTION_DEFINITION meta function. If a function does not require input arguments, an empty dictionary should be provided.
     3. linked_account_owner_id: to specify with credentials of which linked account the
     function should be executed.
     """
 
     function_name: str
-    function_parameters: dict
+    function_arguments: dict
     linked_account_owner_id: str
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,7 +29,7 @@ This example demonstrates the simplest way to use Aipolabs functions with an LLM
 
 ## Key Differences Between example 2 and 3
 
-- In example 2, the retrieved function definition (e.g., `BRAVE_SEARCH__WEB_SEARCH`) is fed directly to the LLM as chat text, and the LLM generates parameters based on the function definition and then generates a `AIPOLABS_EXECUTE_FUNCTION` function call.
+- In example 2, the retrieved function definition (e.g., `BRAVE_SEARCH__WEB_SEARCH`) is fed directly to the LLM as chat text, and the LLM generates function arguments based on the function definition and then generates a `AIPOLABS_EXECUTE_FUNCTION` function call.
 
 - In example 3, the retrieved function definition is stored in the `tools_retrieved` list, and can be dynamically appended to or removed from the LLM's tool list. The LLM will generate a direct function call that matches the retrieved function. (e.g., `BRAVE_SEARCH__WEB_SEARCH`)
 

--- a/examples/agent_with_dynamic_function_discovery_and_fixed_tools.py
+++ b/examples/agent_with_dynamic_function_discovery_and_fixed_tools.py
@@ -24,7 +24,7 @@ prompt = (
     "You can use AIPOLABS_SEARCH_APPS to find relevant apps (which include a set of functions), if you find Apps that might help with your tasks you can use AIPOLABS_SEARCH_FUNCTIONS to find relevant functions within certain apps."
     "You can also use AIPOLABS_SEARCH_FUNCTIONS directly to find relevant functions across all apps."
     "Once you have identified the function you need to use, you can use AIPOLABS_GET_FUNCTION_DEFINITION to get the definition of the function."
-    "You can then use AIPOLABS_EXECUTE_FUNCTION to execute the function provided you have the correct parameters."
+    "You can then use AIPOLABS_EXECUTE_FUNCTION to execute the function provided you have the correct input arguments."
     "So the typical order is AIPOLABS_SEARCH_APPS -> AIPOLABS_SEARCH_FUNCTIONS -> AIPOLABS_GET_FUNCTION_DEFINITION -> AIPOLABS_EXECUTE_FUNCTION."
 )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ from aipolabs import Aipolabs
 from aipolabs._constants import DEFAULT_AIPOLABS_BASE_URL
 from aipolabs._exceptions import APIKeyNotFound
 
-from .conftest import MOCK_API_KEY, MOCK_BASE_URL
+from .utils import MOCK_API_KEY, MOCK_BASE_URL
 
 
 def test_client_initialization() -> None:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -19,7 +19,7 @@ from .utils import MOCK_BASE_URL
 
 MOCK_LINKED_ACCOUNT_OWNER_ID = "123"
 MOCK_FUNCTION_NAME = "TEST_FUNCTION"
-MOCK_FUNCTION_PARAMETERS = {"param1": "value1", "param2": "value2"}
+MOCK_FUNCTION_ARGUMENTS = {"param1": "value1", "param2": "value2"}
 
 
 @respx.mock
@@ -127,20 +127,20 @@ def test_get_function_definition_not_found(client: Aipolabs) -> None:
 
 @respx.mock
 @pytest.mark.parametrize(
-    "function_parameters",
+    "function_arguments",
     [
         {},
-        MOCK_FUNCTION_PARAMETERS,
+        MOCK_FUNCTION_ARGUMENTS,
     ],
 )
-def test_execute_function_success(client: Aipolabs, function_parameters: dict) -> None:
+def test_execute_function_success(client: Aipolabs, function_arguments: dict) -> None:
     mock_response = {"success": True, "data": "string"}
     route = respx.post(f"{MOCK_BASE_URL}functions/{MOCK_FUNCTION_NAME}/execute").mock(
         return_value=httpx.Response(200, json=mock_response)
     )
 
     response = client.functions.execute(
-        MOCK_FUNCTION_NAME, function_parameters, MOCK_LINKED_ACCOUNT_OWNER_ID
+        MOCK_FUNCTION_NAME, function_arguments, MOCK_LINKED_ACCOUNT_OWNER_ID
     )
     assert response.model_dump(exclude_none=True) == mock_response
     assert route.call_count == 1, "should not retry"
@@ -154,7 +154,7 @@ def test_execute_function_bad_request(client: Aipolabs) -> None:
 
     with pytest.raises(ValidationError) as exc_info:
         client.functions.execute(
-            MOCK_FUNCTION_NAME, MOCK_FUNCTION_PARAMETERS, MOCK_LINKED_ACCOUNT_OWNER_ID
+            MOCK_FUNCTION_NAME, MOCK_FUNCTION_ARGUMENTS, MOCK_LINKED_ACCOUNT_OWNER_ID
         )
 
     assert "Bad request" in str(exc_info.value)
@@ -169,7 +169,7 @@ def test_execute_function_rate_limit_exceeded(client: Aipolabs) -> None:
 
     with pytest.raises(RateLimitError) as exc_info:
         client.functions.execute(
-            MOCK_FUNCTION_NAME, MOCK_FUNCTION_PARAMETERS, MOCK_LINKED_ACCOUNT_OWNER_ID
+            MOCK_FUNCTION_NAME, MOCK_FUNCTION_ARGUMENTS, MOCK_LINKED_ACCOUNT_OWNER_ID
         )
 
     assert "Rate limit exceeded" in str(exc_info.value)
@@ -184,7 +184,7 @@ def test_execute_function_server_error(client: Aipolabs) -> None:
 
     with pytest.raises(ServerError) as exc_info:
         client.functions.execute(
-            MOCK_FUNCTION_NAME, MOCK_FUNCTION_PARAMETERS, MOCK_LINKED_ACCOUNT_OWNER_ID
+            MOCK_FUNCTION_NAME, MOCK_FUNCTION_ARGUMENTS, MOCK_LINKED_ACCOUNT_OWNER_ID
         )
 
     assert route.call_count == DEFAULT_MAX_RETRIES, "should retry"
@@ -199,7 +199,7 @@ def test_execute_function_unknown_error(client: Aipolabs) -> None:
 
     with pytest.raises(UnknownError):
         client.functions.execute(
-            MOCK_FUNCTION_NAME, MOCK_FUNCTION_PARAMETERS, MOCK_LINKED_ACCOUNT_OWNER_ID
+            MOCK_FUNCTION_NAME, MOCK_FUNCTION_ARGUMENTS, MOCK_LINKED_ACCOUNT_OWNER_ID
         )
 
     assert route.call_count == DEFAULT_MAX_RETRIES, "should retry"
@@ -213,7 +213,7 @@ def test_execute_function_timeout_exception(client: Aipolabs) -> None:
 
     with pytest.raises(httpx.TimeoutException) as exc_info:
         client.functions.execute(
-            MOCK_FUNCTION_NAME, MOCK_FUNCTION_PARAMETERS, MOCK_LINKED_ACCOUNT_OWNER_ID
+            MOCK_FUNCTION_NAME, MOCK_FUNCTION_ARGUMENTS, MOCK_LINKED_ACCOUNT_OWNER_ID
         )
 
     assert "Request timed out" in str(exc_info.value)
@@ -228,7 +228,7 @@ def test_execute_function_network_error(client: Aipolabs) -> None:
 
     with pytest.raises(httpx.NetworkError) as exc_info:
         client.functions.execute(
-            MOCK_FUNCTION_NAME, MOCK_FUNCTION_PARAMETERS, MOCK_LINKED_ACCOUNT_OWNER_ID
+            MOCK_FUNCTION_NAME, MOCK_FUNCTION_ARGUMENTS, MOCK_LINKED_ACCOUNT_OWNER_ID
         )
 
     assert "Network error" in str(exc_info.value)
@@ -249,7 +249,7 @@ def test_execute_function_retry_on_server_error(client: Aipolabs) -> None:
     )
 
     response = client.functions.execute(
-        MOCK_FUNCTION_NAME, MOCK_FUNCTION_PARAMETERS, MOCK_LINKED_ACCOUNT_OWNER_ID
+        MOCK_FUNCTION_NAME, MOCK_FUNCTION_ARGUMENTS, MOCK_LINKED_ACCOUNT_OWNER_ID
     )
     assert route.call_count == 3, "should retry until success"
     assert response.model_dump(exclude_none=True) == mock_success_response
@@ -269,7 +269,7 @@ def test_execute_function_retry_exhausted(client: Aipolabs) -> None:
 
     with pytest.raises(ServerError) as exc_info:
         client.functions.execute(
-            MOCK_FUNCTION_NAME, MOCK_FUNCTION_PARAMETERS, MOCK_LINKED_ACCOUNT_OWNER_ID
+            MOCK_FUNCTION_NAME, MOCK_FUNCTION_ARGUMENTS, MOCK_LINKED_ACCOUNT_OWNER_ID
         )
 
     assert route.call_count == DEFAULT_MAX_RETRIES, "should retry"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -48,16 +48,16 @@ def test_handle_function_call_search_functions(client: Aipolabs) -> None:
 
 @respx.mock
 def test_handle_function_call_get_function_definition(client: Aipolabs) -> None:
-    function_parameters = {"function_name": "TEST_FUNCTION"}
+    function_arguments = {"function_name": "TEST_FUNCTION"}
     mock_response = {"function": {"name": "Test Function"}}
-    # note: the functio name for mock route here should be function_name in the function_parameters
+    # note: the function name for mock route here should be function_name in the function_arguments
     route = respx.get(
-        f"{MOCK_BASE_URL}functions/{function_parameters['function_name']}/definition"
+        f"{MOCK_BASE_URL}functions/{function_arguments['function_name']}/definition"
     ).mock(return_value=httpx.Response(200, json=mock_response))
 
     response = client.handle_function_call(
         AipolabsGetFunctionDefinition.NAME,
-        function_parameters,
+        function_arguments,
         linked_account_owner_id=MOCK_LINKED_ACCOUNT_OWNER_ID,
     )
     assert isinstance(response, dict)
@@ -67,19 +67,19 @@ def test_handle_function_call_get_function_definition(client: Aipolabs) -> None:
 
 @respx.mock
 def test_handle_function_call_meta_function_execution(client: Aipolabs) -> None:
-    function_parameters = {
+    function_arguments = {
         "function_name": "BRAVE_SEARCH__WEB_SEARCH",
-        "function_parameters": {"param1": "value1"},
+        "function_arguments": {"param1": "value1"},
     }
     mock_response = {"success": True, "data": "string"}
-    # note: the functio name for mock route here should be function_name in the function_parameters
+    # note: the function name for mock route here should be function_name in the function_arguments
     route = respx.post(
-        f"{MOCK_BASE_URL}functions/{function_parameters['function_name']}/execute"
+        f"{MOCK_BASE_URL}functions/{function_arguments['function_name']}/execute"
     ).mock(return_value=httpx.Response(200, json=mock_response))
 
     response = client.handle_function_call(
         AipolabsExecuteFunction.NAME,
-        function_parameters,
+        function_arguments,
         linked_account_owner_id=MOCK_LINKED_ACCOUNT_OWNER_ID,
     )
     assert response == mock_response
@@ -89,7 +89,7 @@ def test_handle_function_call_meta_function_execution(client: Aipolabs) -> None:
 @respx.mock
 def test_handle_function_call_direct_indexed_function_execution(client: Aipolabs) -> None:
     function_name = "BRAVE_SEARCH__WEB_SEARCH"
-    function_parameters = {"query": "test"}
+    function_arguments = {"query": "test"}
     mock_response = {
         "success": True,
         "data": {"results": [{"title": "Test Result"}], "metadata": None},
@@ -100,7 +100,7 @@ def test_handle_function_call_direct_indexed_function_execution(client: Aipolabs
     )
     response = client.handle_function_call(
         function_name,
-        function_parameters,
+        function_arguments,
         linked_account_owner_id=MOCK_LINKED_ACCOUNT_OWNER_ID,
     )
 


### PR DESCRIPTION
Renaming the input generated by llm to function_arguments to stay close to openai term.