### PR TITLE
fix: use InferenceProvider enum's str value in actual request

### DIFF
--- a/aipolabs/resource/functions.py
+++ b/aipolabs/resource/functions.py
@@ -90,7 +90,7 @@ class FunctionsResource(APIResource):
         )
         response = self._httpx_client.get(
             f"functions/{validated_params.function_name}/definition",
-            params={"inference_provider": validated_params.inference_provider},
+            params={"inference_provider": validated_params.inference_provider.value},
         )
 
         function_definition: dict = self._handle_response(response)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -78,7 +78,7 @@ def test_get_function_definition_success(
 ) -> None:
     route = respx.get(
         f"{MOCK_BASE_URL}functions/{MOCK_FUNCTION_NAME}/definition",
-        params={"inference_provider": inference_provider},
+        params={"inference_provider": inference_provider.value},
     ).mock(return_value=httpx.Response(200, json=mock_response))
 
     response = client.functions.get_definition(MOCK_FUNCTION_NAME, inference_provider)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of provider information during definition retrieval to ensure consistent and accurate responses.
- **Tests**
  - Updated tests to verify that definition retrieval works reliably under the new handling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->