### PR TITLE
fix: Fix httpx version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,7 @@ authors = ["Aipolabs <support@aipolabs.xyz>"]
 readme = "README.md"
 homepage = "https://aci.dev"
 repository = "https://github.com/aipotheosis-labs/aipolabs-python"
-packages = [
-    { include = "aipolabs", from = "." }
-]
+packages = [{ include = "aipolabs", from = "." }]
 classifiers = [
     "Typing :: Typed",
     "Development Status :: 4 - Beta",
@@ -28,7 +26,7 @@ classifiers = [
 python = "^3.10"
 pydantic = "^2.9.2"
 typing-extensions = "^4.12.0"
-httpx = "^0.27.2"
+httpx = ">=0.27.2,<1"
 tenacity = "^9.0.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
`httpx = "^0.27.2"` would prevent libraries with `httpx="^0.28.0"` to be used with our library, so it's better to be more relaxed on the minor versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced dependency compatibility by updating version constraints.
	- Streamlined package configuration for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->