### PR TITLE
Feat/util  convert function to json schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,75 @@ else:
     print(result.error)
 ```
 
+### Utility functions
+#### to_json_schema
+Convert a local python function to a LLM compatible tool schema, so you can use custom functions (tools) along with ACI.dev functions (tools).
+```python
+from aipolabs import to_json_schema
+
+# dummy function to test the schema conversion
+def custom_function(
+    required_int: int,
+    optional_str_with_default: str = "default string",
+) -> None:
+    """This is a test function.
+
+    Args:
+        required_int: This is required_int.
+        optional_str_with_default: This is optional_str_with_default.
+    """
+    pass
+
+# for openai chat completions api
+custom_function_openai_chat_completions = to_json_schema(custom_function, FunctionDefinitionFormat.OPENAI)
+"""result:
+{
+    "type": "function",
+    "function": {
+        "name": "custom_function",
+        "description": "This is a test function.",
+        "parameters": {
+            "properties": {
+                "required_int": {
+                    "description": "This is required_int.",
+                    "title": "Required Int",
+                    "type": "integer"
+                },
+                "optional_str_with_default": {
+                    "default": "default string",
+                    "description": "This is optional_str_with_default.",
+                    "title": "Optional Str With Default",
+                    "type": "string"
+                }
+            },
+            "required": ["required_int"],
+            "title": "custom_function_args",
+            "type": "object",
+            "additionalProperties": False
+        }
+    }
+}
+"""
+
+# alternative format: for openai responses api
+custom_function_openai_responses = to_json_schema(custom_function, FunctionDefinitionFormat.OPENAI_RESPONSES)
+
+# alternative format: for anthropic api
+custom_function_anthropic = to_json_schema(custom_function, FunctionDefinitionFormat.ANTHROPIC)
+
+# use the tool in a openai chat completion api
+response = openai.chat.completions.create(
+    model="gpt-4o",
+    messages=[
+        {
+            "role": "system",
+            "content": "You are a helpful assistant with access to a variety of tools.",
+        },
+    ],
+    tools=[custom_function_openai_chat_completions]
+)
+```
+
 ### Agent-centric features
 The SDK provides a suite of features and helper functions to make it easier and more seamless to use functions in LLM powered agentic applications.
 This is our vision and the recommended way of trying out the SDK.

--- a/aipolabs/__init__.py
+++ b/aipolabs/__init__.py
@@ -1,6 +1,7 @@
 from aipolabs._client import ACI
+from aipolabs.libs._tool import to_json_schema
 from aipolabs.utils._logging import setup_logging as _setup_logging
 
 _setup_logging()
 
-__all__ = ["ACI"]
+__all__ = ["ACI", "to_json_schema"]

--- a/aipolabs/libs/_compatible_schema.py
+++ b/aipolabs/libs/_compatible_schema.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from typing_extensions import TypeGuard, override
+
+"""
+This file is a modified version of the `strict_schema.py` file from the `openai` library.
+https://github.com/openai/openai-agents-python/blob/064e25b01b5c82c08aea66ff898ff27adbb013d8/src/agents/strict_schema.py
+It is used to ensure that the JSON schema is compatible with the OpenAI API. (not to enforce `strict` schema)
+"""
+
+
+# Sentinel class used until PEP 0661 is accepted
+class NotGiven:
+    """
+    A sentinel singleton class used to distinguish omitted keyword arguments
+    from those passed in with the value None (which may have different behavior).
+
+    For example:
+
+    ```py
+    def get(timeout: Union[int, NotGiven, None] = NotGiven()) -> Response: ...
+
+
+    get(timeout=1)  # 1s timeout
+    get(timeout=None)  # No timeout
+    get()  # Default timeout behavior, which may not be statically known at the method definition.
+    ```
+    """
+
+    def __bool__(self) -> Literal[False]:
+        return False
+
+    @override
+    def __repr__(self) -> str:
+        return "NOT_GIVEN"
+
+
+NOT_GIVEN = NotGiven()
+
+_EMPTY_SCHEMA = {
+    "additionalProperties": False,
+    "type": "object",
+    "properties": {},
+    "required": [],
+}
+
+
+def ensure_llm_compatible_json_schema(
+    schema: dict[str, Any],
+) -> dict[str, Any]:
+    """Mutates the given JSON schema to ensure it conforms to the `strict` standard
+    that the OpenAI API expects.
+    """
+    if schema == {}:
+        return _EMPTY_SCHEMA
+    return _ensure_llm_compatible_json_schema(schema, path=(), root=schema)
+
+
+# Adapted from https://github.com/openai/openai-python/blob/main/src/openai/lib/_pydantic.py
+def _ensure_llm_compatible_json_schema(
+    json_schema: object,
+    *,
+    path: tuple[str, ...],
+    root: dict[str, object],
+) -> dict[str, Any]:
+    if not is_dict(json_schema):
+        raise TypeError(f"Expected {json_schema} to be a dictionary; path={path}")
+
+    defs = json_schema.get("$defs")
+    if is_dict(defs):
+        for def_name, def_schema in defs.items():
+            _ensure_llm_compatible_json_schema(
+                def_schema, path=(*path, "$defs", def_name), root=root
+            )
+
+    definitions = json_schema.get("definitions")
+    if is_dict(definitions):
+        for definition_name, definition_schema in definitions.items():
+            _ensure_llm_compatible_json_schema(
+                definition_schema, path=(*path, "definitions", definition_name), root=root
+            )
+
+    typ = json_schema.get("type")
+    if typ == "object" and "additionalProperties" not in json_schema:
+        json_schema["additionalProperties"] = False
+
+    # object types
+    # { 'type': 'object', 'properties': { 'a':  {...} } }
+    properties = json_schema.get("properties")
+    if is_dict(properties):
+        # NOTE: we don't want this (All fields in properties must be marked as required)
+        # because we are using the `strict_mode=False` only for openai schema
+        # json_schema["required"] = list(properties.keys())
+        json_schema["properties"] = {
+            key: _ensure_llm_compatible_json_schema(
+                prop_schema, path=(*path, "properties", key), root=root
+            )
+            for key, prop_schema in properties.items()
+        }
+
+    # arrays
+    # { 'type': 'array', 'items': {...} }
+    items = json_schema.get("items")
+    if is_dict(items):
+        json_schema["items"] = _ensure_llm_compatible_json_schema(
+            items, path=(*path, "items"), root=root
+        )
+
+    # unions
+    any_of = json_schema.get("anyOf")
+    if is_list(any_of):
+        json_schema["anyOf"] = [
+            _ensure_llm_compatible_json_schema(variant, path=(*path, "anyOf", str(i)), root=root)
+            for i, variant in enumerate(any_of)
+        ]
+
+    # intersections
+    all_of = json_schema.get("allOf")
+    if is_list(all_of):
+        if len(all_of) == 1:
+            json_schema.update(
+                _ensure_llm_compatible_json_schema(all_of[0], path=(*path, "allOf", "0"), root=root)
+            )
+            json_schema.pop("allOf")
+        else:
+            json_schema["allOf"] = [
+                _ensure_llm_compatible_json_schema(entry, path=(*path, "allOf", str(i)), root=root)
+                for i, entry in enumerate(all_of)
+            ]
+
+    # strip `None` defaults as there's no meaningful distinction here
+    # the schema will still be `nullable` and the model will default
+    # to using `None` anyway
+    if json_schema.get("default", NOT_GIVEN) is None:
+        json_schema.pop("default")
+
+    # we can't use `$ref`s if there are also other properties defined, e.g.
+    # `{"$ref": "...", "description": "my description"}`
+    #
+    # so we unravel the ref
+    # `{"type": "string", "description": "my description"}`
+    ref = json_schema.get("$ref")
+    if ref and has_more_than_n_keys(json_schema, 1):
+        assert isinstance(ref, str), f"Received non-string $ref - {ref}"
+
+        resolved = resolve_ref(root=root, ref=ref)
+        if not is_dict(resolved):
+            raise ValueError(
+                f"Expected `$ref: {ref}` to resolved to a dictionary but got {resolved}"
+            )
+
+        # properties from the json schema take priority over the ones on the `$ref`
+        json_schema.update({**resolved, **json_schema})
+        json_schema.pop("$ref")
+        # Since the schema expanded from `$ref` might not have `additionalProperties: false` applied
+        # we call `_ensure_llm_compatible_json_schema` again to fix the inlined schema and ensure it's valid
+        return _ensure_llm_compatible_json_schema(json_schema, path=path, root=root)
+
+    return json_schema
+
+
+def resolve_ref(*, root: dict[str, object], ref: str) -> object:
+    if not ref.startswith("#/"):
+        raise ValueError(f"Unexpected $ref format {ref!r}; Does not start with #/")
+
+    path = ref[2:].split("/")
+    resolved = root
+    for key in path:
+        value = resolved[key]
+        assert is_dict(
+            value
+        ), f"encountered non-dictionary entry while resolving {ref} - {resolved}"
+        resolved = value
+
+    return resolved
+
+
+def is_dict(obj: object) -> TypeGuard[dict[str, object]]:
+    # just pretend that we know there are only `str` keys
+    # as that check is not worth the performance cost
+    return isinstance(obj, dict)
+
+
+def is_list(obj: object) -> TypeGuard[list[object]]:
+    return isinstance(obj, list)
+
+
+def has_more_than_n_keys(obj: dict[str, object], n: int) -> bool:
+    i = 0
+    for _ in obj.keys():
+        i += 1
+        if i > n:
+            return True
+    return False

--- a/aipolabs/libs/_compatible_schema.py
+++ b/aipolabs/libs/_compatible_schema.py
@@ -142,7 +142,9 @@ def _ensure_llm_compatible_json_schema(
     # so we unravel the ref
     # `{"type": "string", "description": "my description"}`
     ref = json_schema.get("$ref")
-    if ref and has_more_than_n_keys(json_schema, 1):
+    # NOTE: opinionated change: we expand refs regardless of the number of keys. previously, we only expanded refs
+    # if there was only one key in the json schema. (has_more_than_n_keys(json_schema, 1))
+    if ref:
         assert isinstance(ref, str), f"Received non-string $ref - {ref}"
 
         resolved = resolve_ref(root=root, ref=ref)

--- a/aipolabs/libs/_function_schema.py
+++ b/aipolabs/libs/_function_schema.py
@@ -306,6 +306,9 @@ def function_schema(
     # 'strict' mode in openai
     json_schema = ensure_llm_compatible_json_schema(json_schema)
 
+    # 4.2 NOTE: opinionated change: pop the '$defs' key from the json schema (we can safely do this because we expand all 'refs')
+    json_schema.pop("$defs")
+
     # 5. Return as a FuncSchema dataclass
     return FuncSchema(
         name=func_name,

--- a/aipolabs/libs/_function_schema.py
+++ b/aipolabs/libs/_function_schema.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import contextlib
+import inspect
+import logging
+import re
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Literal,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+from griffe import Docstring, DocstringSectionKind
+from pydantic import BaseModel, Field, create_model
+
+from ._compatible_schema import ensure_llm_compatible_json_schema
+
+"""
+This file is a modified version of the `function_schema.py` file from the `openai` library.
+https://github.com/openai/openai-agents-python/blob/064e25b01b5c82c08aea66ff898ff27adbb013d8/src/agents/function_schema.py
+It is used to extract the schema for a python function, in preparation for sending it to an LLM as a tool.
+"""
+
+
+@dataclass
+class FuncSchema:
+    """
+    Captures the schema for a python function, in preparation for sending it to an LLM as a tool.
+    """
+
+    name: str
+    """The name of the function."""
+    description: str | None
+    """The description of the function."""
+    params_pydantic_model: type[BaseModel]
+    """A Pydantic model that represents the function's parameters."""
+    params_json_schema: dict[str, Any]
+    """The JSON schema for the function's parameters, derived from the Pydantic model."""
+    signature: inspect.Signature
+    """The signature of the function."""
+
+    def to_call_args(self, data: BaseModel) -> tuple[list[Any], dict[str, Any]]:
+        """
+        Converts validated data from the Pydantic model into (args, kwargs), suitable for calling
+        the original function.
+        """
+        positional_args: list[Any] = []
+        keyword_args: dict[str, Any] = {}
+        seen_var_positional = False
+
+        for name, param in self.signature.parameters.items():
+            value = getattr(data, name, None)
+            if param.kind == param.VAR_POSITIONAL:
+                # e.g. *args: extend positional args and mark that *args is now seen
+                positional_args.extend(value or [])
+                seen_var_positional = True
+            elif param.kind == param.VAR_KEYWORD:
+                # e.g. **kwargs handling
+                keyword_args.update(value or {})
+            elif param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
+                # Before *args, add to positional args. After *args, add to keyword args.
+                if not seen_var_positional:
+                    positional_args.append(value)
+                else:
+                    keyword_args[name] = value
+            else:
+                # For KEYWORD_ONLY parameters, always use keyword args.
+                keyword_args[name] = value
+        return positional_args, keyword_args
+
+
+@dataclass
+class FuncDocumentation:
+    """Contains metadata about a python function, extracted from its docstring."""
+
+    name: str
+    """The name of the function, via `__name__`."""
+    description: str | None
+    """The description of the function, derived from the docstring."""
+    param_descriptions: dict[str, str] | None
+    """The parameter descriptions of the function, derived from the docstring."""
+
+
+DocstringStyle = Literal["google", "numpy", "sphinx"]
+
+
+# As of Feb 2025, the automatic style detection in griffe is an Insiders feature. This
+# code approximates it.
+def _detect_docstring_style(doc: str) -> DocstringStyle:
+    scores: dict[DocstringStyle, int] = {"sphinx": 0, "numpy": 0, "google": 0}
+
+    # Sphinx style detection: look for :param, :type, :return:, and :rtype:
+    sphinx_patterns = [r"^:param\s", r"^:type\s", r"^:return:", r"^:rtype:"]
+    for pattern in sphinx_patterns:
+        if re.search(pattern, doc, re.MULTILINE):
+            scores["sphinx"] += 1
+
+    # Numpy style detection: look for headers like 'Parameters', 'Returns', or 'Yields' followed by
+    # a dashed underline
+    numpy_patterns = [
+        r"^Parameters\s*\n\s*-{3,}",
+        r"^Returns\s*\n\s*-{3,}",
+        r"^Yields\s*\n\s*-{3,}",
+    ]
+    for pattern in numpy_patterns:
+        if re.search(pattern, doc, re.MULTILINE):
+            scores["numpy"] += 1
+
+    # Google style detection: look for section headers with a trailing colon
+    google_patterns = [r"^(Args|Arguments):", r"^(Returns):", r"^(Raises):"]
+    for pattern in google_patterns:
+        if re.search(pattern, doc, re.MULTILINE):
+            scores["google"] += 1
+
+    max_score = max(scores.values())
+    if max_score == 0:
+        return "google"
+
+    # Priority order: sphinx > numpy > google in case of tie
+    styles: list[DocstringStyle] = ["sphinx", "numpy", "google"]
+
+    for style in styles:
+        if scores[style] == max_score:
+            return style
+
+    return "google"
+
+
+@contextlib.contextmanager
+def _suppress_griffe_logging() -> Generator[None, None, None]:
+    # Supresses warnings about missing annotations for params
+    logger = logging.getLogger("griffe")
+    previous_level = logger.getEffectiveLevel()
+    logger.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        logger.setLevel(previous_level)
+
+
+def generate_func_documentation(
+    func: Callable[..., Any], style: DocstringStyle | None = None
+) -> FuncDocumentation:
+    """
+    Extracts metadata from a function docstring, in preparation for sending it to an LLM as a tool.
+
+    Args:
+        func: The function to extract documentation from.
+        style: The style of the docstring to use for parsing. If not provided, we will attempt to
+            auto-detect the style.
+
+    Returns:
+        A FuncDocumentation object containing the function's name, description, and parameter
+        descriptions.
+    """
+    name = func.__name__
+    doc = inspect.getdoc(func)
+    if not doc:
+        return FuncDocumentation(name=name, description=None, param_descriptions=None)
+
+    with _suppress_griffe_logging():
+        docstring = Docstring(doc, lineno=1, parser=style or _detect_docstring_style(doc))
+        parsed = docstring.parse()
+
+    description: str | None = next(
+        (section.value for section in parsed if section.kind == DocstringSectionKind.text), None
+    )
+
+    param_descriptions: dict[str, str] = {
+        param.name: param.description
+        for section in parsed
+        if section.kind == DocstringSectionKind.parameters
+        for param in section.value
+    }
+
+    return FuncDocumentation(
+        name=func.__name__,
+        description=description,
+        param_descriptions=param_descriptions or None,
+    )
+
+
+def function_schema(
+    func: Callable[..., Any],
+    docstring_style: DocstringStyle | None = None,
+    name_override: str | None = None,
+    description_override: str | None = None,
+    use_docstring_info: bool = True,
+) -> FuncSchema:
+    """
+    Given a python function, extracts a `FuncSchema` from it, capturing the name, description,
+    parameter descriptions, and other metadata.
+
+    Args:
+        func: The function to extract the schema from.
+        docstring_style: The style of the docstring to use for parsing. If not provided, we will
+            attempt to auto-detect the style.
+        name_override: If provided, use this name instead of the function's `__name__`.
+        description_override: If provided, use this description instead of the one derived from the
+            docstring.
+        use_docstring_info: If True, uses the docstring to generate the description and parameter
+            descriptions.
+
+    Returns:
+        A `FuncSchema` object containing the function's name, description, parameter descriptions,
+        and other metadata.
+    """
+
+    # 1. Grab docstring info
+    if use_docstring_info:
+        doc_info = generate_func_documentation(func, docstring_style)
+        param_descs = doc_info.param_descriptions or {}
+    else:
+        doc_info = None
+        param_descs = {}
+
+    func_name = name_override or doc_info.name if doc_info else func.__name__
+
+    # 2. Inspect function signature and get type hints
+    sig = inspect.signature(func)
+    type_hints = get_type_hints(func)
+    params = list(sig.parameters.items())
+    filtered_params = params
+
+    # We will collect field definitions for create_model as a dict:
+    #   field_name -> (type_annotation, default_value_or_Field(...))
+    fields: dict[str, Any] = {}
+
+    for name, param in filtered_params:
+        ann = type_hints.get(name, param.annotation)
+        default = param.default
+
+        # If there's no type hint, assume `Any`
+        if ann == inspect._empty:
+            ann = Any
+
+        # If a docstring param description exists, use it
+        field_description = param_descs.get(name, None)
+
+        # Handle different parameter kinds
+        if param.kind == param.VAR_POSITIONAL:
+            # e.g. *args: extend positional args
+            if get_origin(ann) is tuple:
+                # e.g. def foo(*args: tuple[int, ...]) -> treat as List[int]
+                args_of_tuple = get_args(ann)
+                if len(args_of_tuple) == 2 and args_of_tuple[1] is Ellipsis:
+                    ann = list[args_of_tuple[0]]  # type: ignore
+                else:
+                    ann = list[Any]
+            else:
+                # If user wrote *args: int, treat as List[int]
+                ann = list[ann]  # type: ignore
+
+            # Default factory to empty list
+            fields[name] = (
+                ann,
+                Field(default_factory=list, description=field_description),
+            )
+
+        elif param.kind == param.VAR_KEYWORD:
+            # **kwargs handling
+            if get_origin(ann) is dict:
+                # e.g. def foo(**kwargs: dict[str, int])
+                dict_args = get_args(ann)
+                if len(dict_args) == 2:
+                    ann = dict[dict_args[0], dict_args[1]]  # type: ignore
+                else:
+                    ann = dict[str, Any]
+            else:
+                # e.g. def foo(**kwargs: int) -> Dict[str, int]
+                ann = dict[str, ann]  # type: ignore
+
+            fields[name] = (
+                ann,
+                Field(default_factory=dict, description=field_description),
+            )
+
+        else:
+            # Normal parameter
+            if default == inspect._empty:
+                # Required field
+                fields[name] = (
+                    ann,
+                    Field(..., description=field_description),
+                )
+            else:
+                # Parameter with a default value
+                fields[name] = (
+                    ann,
+                    Field(default=default, description=field_description),
+                )
+
+    # 3. Dynamically build a Pydantic model
+    dynamic_model = create_model(f"{func_name}_args", __base__=BaseModel, **fields)
+
+    # 4. Build JSON schema from that model
+    json_schema = dynamic_model.model_json_schema()
+
+    # 4.1 NOTE:post process json schema (somehow without this, the json schema is not valid for openai)
+    # this is mostly the same as orignal 'ensure_strict_json_schema' function with changes to not enforce
+    # 'strict' mode in openai
+    json_schema = ensure_llm_compatible_json_schema(json_schema)
+
+    # 5. Return as a FuncSchema dataclass
+    return FuncSchema(
+        name=func_name,
+        description=description_override or doc_info.description if doc_info else None,
+        params_pydantic_model=dynamic_model,
+        params_json_schema=json_schema,
+        signature=sig,
+    )

--- a/aipolabs/libs/_function_schema.py
+++ b/aipolabs/libs/_function_schema.py
@@ -307,7 +307,8 @@ def function_schema(
     json_schema = ensure_llm_compatible_json_schema(json_schema)
 
     # 4.2 NOTE: opinionated change: pop the '$defs' key from the json schema (we can safely do this because we expand all 'refs')
-    json_schema.pop("$defs")
+    if "$defs" in json_schema:
+        json_schema.pop("$defs")
 
     # 5. Return as a FuncSchema dataclass
     return FuncSchema(

--- a/aipolabs/libs/_tool.py
+++ b/aipolabs/libs/_tool.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Literal, Optional, TypedDict, Union, overload
+
+from ._function_schema import DocstringStyle, function_schema
+
+"""
+This file is a modified version of the `tool.py` file from the `openai` library.
+https://github.com/openai/openai-agents-python/blob/064e25b01b5c82c08aea66ff898ff27adbb013d8/src/agents/tool.py
+It is used to convert a Python function to an LLM tool schema in the specified format.
+"""
+
+
+# Schema format types
+SchemaFormat = Literal["openai", "anthropic"]
+
+
+# Schema type definitions
+class OpenAISchema(TypedDict):
+    type: Literal["function"]
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+
+
+class AnthropicSchema(TypedDict):
+    name: str
+    description: str
+    input_schema: Dict[str, Any]
+
+
+@overload
+def to_json_schema(
+    func: Callable[..., Any],
+    format: Literal["openai"],
+    *,
+    name_override: Optional[str] = None,
+    description_override: Optional[str] = None,
+    docstring_style: Optional[DocstringStyle] = None,
+    use_docstring_info: bool = True,
+) -> OpenAISchema: ...
+
+
+@overload
+def to_json_schema(
+    func: Callable[..., Any],
+    format: Literal["anthropic"],
+    *,
+    name_override: Optional[str] = None,
+    description_override: Optional[str] = None,
+    docstring_style: Optional[DocstringStyle] = None,
+    use_docstring_info: bool = True,
+) -> AnthropicSchema: ...
+
+
+def to_json_schema(
+    func: Callable[..., Any],
+    format: SchemaFormat = "openai",
+    *,
+    name_override: Optional[str] = None,
+    description_override: Optional[str] = None,
+    docstring_style: Optional[DocstringStyle] = None,
+    use_docstring_info: bool = True,
+) -> Union[OpenAISchema, AnthropicSchema]:
+    """
+    Convert a Python function to an LLM tool schema in the specified format.
+
+    Args:
+        func: The function to convert to a schema
+        format: The schema format to generate ("openai" or "anthropic")
+        name_override: Optional custom name for the function
+        description_override: Optional custom description
+        docstring_style: Optional docstring style for parsing
+        use_docstring_info: Whether to use function docstring for descriptions
+
+    Returns:
+        A dictionary containing the tool schema in the requested format
+
+    Examples:
+        >>> def get_weather(location: str) -> str:
+        ...     '''Get current temperature for a location.'''
+        ...     return f"Weather information for {location}"
+        ...
+        >>> openai_schema = to_llm_schema(get_weather, "openai")
+        >>> anthropic_schema = to_llm_schema(get_weather, "anthropic")
+    """
+    # Extract base function metadata
+    base_schema = function_schema(
+        func=func,
+        name_override=name_override,
+        description_override=description_override,
+        docstring_style=docstring_style,
+        use_docstring_info=use_docstring_info,
+    )
+
+    # Generate schema based on format
+    if format == "openai":
+        return {
+            "type": "function",
+            "name": base_schema.name,
+            "description": base_schema.description or "",
+            "parameters": base_schema.params_json_schema,
+        }
+    elif format == "anthropic":
+        return {
+            "name": base_schema.name,
+            "description": base_schema.description or "",
+            "input_schema": base_schema.params_json_schema,
+        }
+    else:
+        # This should never happen due to type restrictions, but just in case
+        raise ValueError(f"Unsupported schema format: {format}")

--- a/aipolabs/types/functions.py
+++ b/aipolabs/types/functions.py
@@ -6,7 +6,10 @@ from pydantic import BaseModel
 
 class FunctionDefinitionFormat(str, Enum):
     BASIC = "basic"  # name and description only
-    OPENAI = "openai"  # openai function call format
+    OPENAI = "openai"  # openai function call format (for the chat completions api)
+    OPENAI_RESPONSES = (
+        "openai_responses"  # openai function call format (for the responses api, the newest API)
+    )
     ANTHROPIC = "anthropic"  # anthropic function call format
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -138,17 +138,6 @@ files = [
 ]
 
 [[package]]
-name = "distro"
-version = "1.9.0"
-description = "Distro - an OS platform information API"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
-    {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
@@ -193,6 +182,20 @@ files = [
 mccabe = ">=0.7.0,<0.8.0"
 pycodestyle = ">=2.12.0,<2.13.0"
 pyflakes = ">=3.2.0,<3.3.0"
+
+[[package]]
+name = "griffe"
+version = "1.7.2"
+description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "griffe-1.7.2-py3-none-any.whl", hash = "sha256:1ed9c2e338a75741fc82083fe5a1bc89cb6142efe126194cc313e34ee6af5423"},
+    {file = "griffe-1.7.2.tar.gz", hash = "sha256:98d396d803fab3b680c2608f300872fd57019ed82f0672f5b5323a9ad18c540c"},
+]
+
+[package.dependencies]
+colorama = ">=0.4"
 
 [[package]]
 name = "h11"
@@ -305,86 +308,28 @@ files = [
 colors = ["colorama (>=0.4.6)"]
 
 [[package]]
-name = "jiter"
-version = "0.7.1"
-description = "Fast iterable JSON parser."
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jiter-0.7.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:262e96d06696b673fad6f257e6a0abb6e873dc22818ca0e0600f4a1189eb334f"},
-    {file = "jiter-0.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:be6de02939aac5be97eb437f45cfd279b1dc9de358b13ea6e040e63a3221c40d"},
-    {file = "jiter-0.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:935f10b802bc1ce2b2f61843e498c7720aa7f4e4bb7797aa8121eab017293c3d"},
-    {file = "jiter-0.7.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9cd3cccccabf5064e4bb3099c87bf67db94f805c1e62d1aefd2b7476e90e0ee2"},
-    {file = "jiter-0.7.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4aa919ebfc5f7b027cc368fe3964c0015e1963b92e1db382419dadb098a05192"},
-    {file = "jiter-0.7.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ae2d01e82c94491ce4d6f461a837f63b6c4e6dd5bb082553a70c509034ff3d4"},
-    {file = "jiter-0.7.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f9568cd66dbbdab67ae1b4c99f3f7da1228c5682d65913e3f5f95586b3cb9a9"},
-    {file = "jiter-0.7.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9ecbf4e20ec2c26512736284dc1a3f8ed79b6ca7188e3b99032757ad48db97dc"},
-    {file = "jiter-0.7.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b1a0508fddc70ce00b872e463b387d49308ef02b0787992ca471c8d4ba1c0fa1"},
-    {file = "jiter-0.7.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f84c9996664c460f24213ff1e5881530abd8fafd82058d39af3682d5fd2d6316"},
-    {file = "jiter-0.7.1-cp310-none-win32.whl", hash = "sha256:c915e1a1960976ba4dfe06551ea87063b2d5b4d30759012210099e712a414d9f"},
-    {file = "jiter-0.7.1-cp310-none-win_amd64.whl", hash = "sha256:75bf3b7fdc5c0faa6ffffcf8028a1f974d126bac86d96490d1b51b3210aa0f3f"},
-    {file = "jiter-0.7.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ad04a23a91f3d10d69d6c87a5f4471b61c2c5cd6e112e85136594a02043f462c"},
-    {file = "jiter-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e47a554de88dff701226bb5722b7f1b6bccd0b98f1748459b7e56acac2707a5"},
-    {file = "jiter-0.7.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e44fff69c814a2e96a20b4ecee3e2365e9b15cf5fe4e00869d18396daa91dab"},
-    {file = "jiter-0.7.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df0a1d05081541b45743c965436f8b5a1048d6fd726e4a030113a2699a6046ea"},
-    {file = "jiter-0.7.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f22cf8f236a645cb6d8ffe2a64edb5d2b66fb148bf7c75eea0cb36d17014a7bc"},
-    {file = "jiter-0.7.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:da8589f50b728ea4bf22e0632eefa125c8aa9c38ed202a5ee6ca371f05eeb3ff"},
-    {file = "jiter-0.7.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f20de711224f2ca2dbb166a8d512f6ff48c9c38cc06b51f796520eb4722cc2ce"},
-    {file = "jiter-0.7.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8a9803396032117b85ec8cbf008a54590644a062fedd0425cbdb95e4b2b60479"},
-    {file = "jiter-0.7.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:3d8bae77c82741032e9d89a4026479061aba6e646de3bf5f2fc1ae2bbd9d06e0"},
-    {file = "jiter-0.7.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3dc9939e576bbc68c813fc82f6620353ed68c194c7bcf3d58dc822591ec12490"},
-    {file = "jiter-0.7.1-cp311-none-win32.whl", hash = "sha256:f7605d24cd6fab156ec89e7924578e21604feee9c4f1e9da34d8b67f63e54892"},
-    {file = "jiter-0.7.1-cp311-none-win_amd64.whl", hash = "sha256:f3ea649e7751a1a29ea5ecc03c4ada0a833846c59c6da75d747899f9b48b7282"},
-    {file = "jiter-0.7.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ad36a1155cbd92e7a084a568f7dc6023497df781adf2390c345dd77a120905ca"},
-    {file = "jiter-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7ba52e6aaed2dc5c81a3d9b5e4ab95b039c4592c66ac973879ba57c3506492bb"},
-    {file = "jiter-0.7.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b7de0b6f6728b678540c7927587e23f715284596724be203af952418acb8a2d"},
-    {file = "jiter-0.7.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9463b62bd53c2fb85529c700c6a3beb2ee54fde8bef714b150601616dcb184a6"},
-    {file = "jiter-0.7.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:627164ec01d28af56e1f549da84caf0fe06da3880ebc7b7ee1ca15df106ae172"},
-    {file = "jiter-0.7.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25d0e5bf64e368b0aa9e0a559c3ab2f9b67e35fe7269e8a0d81f48bbd10e8963"},
-    {file = "jiter-0.7.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c244261306f08f8008b3087059601997016549cb8bb23cf4317a4827f07b7d74"},
-    {file = "jiter-0.7.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7ded4e4b75b68b843b7cea5cd7c55f738c20e1394c68c2cb10adb655526c5f1b"},
-    {file = "jiter-0.7.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:80dae4f1889b9d09e5f4de6b58c490d9c8ce7730e35e0b8643ab62b1538f095c"},
-    {file = "jiter-0.7.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5970cf8ec943b51bce7f4b98d2e1ed3ada170c2a789e2db3cb484486591a176a"},
-    {file = "jiter-0.7.1-cp312-none-win32.whl", hash = "sha256:701d90220d6ecb3125d46853c8ca8a5bc158de8c49af60fd706475a49fee157e"},
-    {file = "jiter-0.7.1-cp312-none-win_amd64.whl", hash = "sha256:7824c3ecf9ecf3321c37f4e4d4411aad49c666ee5bc2a937071bdd80917e4533"},
-    {file = "jiter-0.7.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:097676a37778ba3c80cb53f34abd6943ceb0848263c21bf423ae98b090f6c6ba"},
-    {file = "jiter-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3298af506d4271257c0a8f48668b0f47048d69351675dd8500f22420d4eec378"},
-    {file = "jiter-0.7.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12fd88cfe6067e2199964839c19bd2b422ca3fd792949b8f44bb8a4e7d21946a"},
-    {file = "jiter-0.7.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dacca921efcd21939123c8ea8883a54b9fa7f6545c8019ffcf4f762985b6d0c8"},
-    {file = "jiter-0.7.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de3674a5fe1f6713a746d25ad9c32cd32fadc824e64b9d6159b3b34fd9134143"},
-    {file = "jiter-0.7.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65df9dbae6d67e0788a05b4bad5706ad40f6f911e0137eb416b9eead6ba6f044"},
-    {file = "jiter-0.7.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ba9a358d59a0a55cccaa4957e6ae10b1a25ffdabda863c0343c51817610501d"},
-    {file = "jiter-0.7.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:576eb0f0c6207e9ede2b11ec01d9c2182973986514f9c60bc3b3b5d5798c8f50"},
-    {file = "jiter-0.7.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:e550e29cdf3577d2c970a18f3959e6b8646fd60ef1b0507e5947dc73703b5627"},
-    {file = "jiter-0.7.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:81d968dbf3ce0db2e0e4dec6b0a0d5d94f846ee84caf779b07cab49f5325ae43"},
-    {file = "jiter-0.7.1-cp313-none-win32.whl", hash = "sha256:f892e547e6e79a1506eb571a676cf2f480a4533675f834e9ae98de84f9b941ac"},
-    {file = "jiter-0.7.1-cp313-none-win_amd64.whl", hash = "sha256:0302f0940b1455b2a7fb0409b8d5b31183db70d2b07fd177906d83bf941385d1"},
-    {file = "jiter-0.7.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:c65a3ce72b679958b79d556473f192a4dfc5895e8cc1030c9f4e434690906076"},
-    {file = "jiter-0.7.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e80052d3db39f9bb8eb86d207a1be3d9ecee5e05fdec31380817f9609ad38e60"},
-    {file = "jiter-0.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70a497859c4f3f7acd71c8bd89a6f9cf753ebacacf5e3e799138b8e1843084e3"},
-    {file = "jiter-0.7.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c1288bc22b9e36854a0536ba83666c3b1fb066b811019d7b682c9cf0269cdf9f"},
-    {file = "jiter-0.7.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b096ca72dd38ef35675e1d3b01785874315182243ef7aea9752cb62266ad516f"},
-    {file = "jiter-0.7.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8dbbd52c50b605af13dbee1a08373c520e6fcc6b5d32f17738875847fea4e2cd"},
-    {file = "jiter-0.7.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af29c5c6eb2517e71ffa15c7ae9509fa5e833ec2a99319ac88cc271eca865519"},
-    {file = "jiter-0.7.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f114a4df1e40c03c0efbf974b376ed57756a1141eb27d04baee0680c5af3d424"},
-    {file = "jiter-0.7.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:191fbaee7cf46a9dd9b817547bf556facde50f83199d07fc48ebeff4082f9df4"},
-    {file = "jiter-0.7.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:0e2b445e5ee627fb4ee6bbceeb486251e60a0c881a8e12398dfdff47c56f0723"},
-    {file = "jiter-0.7.1-cp38-none-win32.whl", hash = "sha256:47ac4c3cf8135c83e64755b7276339b26cd3c7ddadf9e67306ace4832b283edf"},
-    {file = "jiter-0.7.1-cp38-none-win_amd64.whl", hash = "sha256:60b49c245cd90cde4794f5c30f123ee06ccf42fb8730a019a2870cd005653ebd"},
-    {file = "jiter-0.7.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:8f212eeacc7203256f526f550d105d8efa24605828382cd7d296b703181ff11d"},
-    {file = "jiter-0.7.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d9e247079d88c00e75e297e6cb3a18a039ebcd79fefc43be9ba4eb7fb43eb726"},
-    {file = "jiter-0.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0aacaa56360139c53dcf352992b0331f4057a0373bbffd43f64ba0c32d2d155"},
-    {file = "jiter-0.7.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bc1b55314ca97dbb6c48d9144323896e9c1a25d41c65bcb9550b3e0c270ca560"},
-    {file = "jiter-0.7.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f281aae41b47e90deb70e7386558e877a8e62e1693e0086f37d015fa1c102289"},
-    {file = "jiter-0.7.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:93c20d2730a84d43f7c0b6fb2579dc54335db742a59cf9776d0b80e99d587382"},
-    {file = "jiter-0.7.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e81ccccd8069110e150613496deafa10da2f6ff322a707cbec2b0d52a87b9671"},
-    {file = "jiter-0.7.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a7d5e85766eff4c9be481d77e2226b4c259999cb6862ccac5ef6621d3c8dcce"},
-    {file = "jiter-0.7.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f52ce5799df5b6975439ecb16b1e879d7655e1685b6e3758c9b1b97696313bfb"},
-    {file = "jiter-0.7.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e0c91a0304373fdf97d56f88356a010bba442e6d995eb7773cbe32885b71cdd8"},
-    {file = "jiter-0.7.1-cp39-none-win32.whl", hash = "sha256:5c08adf93e41ce2755970e8aa95262298afe2bf58897fb9653c47cd93c3c6cdc"},
-    {file = "jiter-0.7.1-cp39-none-win_amd64.whl", hash = "sha256:6592f4067c74176e5f369228fb2995ed01400c9e8e1225fb73417183a5e635f0"},
-    {file = "jiter-0.7.1.tar.gz", hash = "sha256:448cf4f74f7363c34cdef26214da527e8eeffd88ba06d0b80b485ad0667baf5d"},
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
 ]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "mccabe"
@@ -395,6 +340,17 @@ python-versions = ">=3.6"
 files = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 
 [[package]]
@@ -471,30 +427,6 @@ files = [
     {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
     {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
 ]
-
-[[package]]
-name = "openai"
-version = "1.55.0"
-description = "The official Python library for the openai API"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "openai-1.55.0-py3-none-any.whl", hash = "sha256:446e08918f8dd70d8723274be860404c8c7cc46b91b93bbc0ef051f57eb503c1"},
-    {file = "openai-1.55.0.tar.gz", hash = "sha256:6c0975ac8540fe639d12b4ff5a8e0bf1424c844c4a4251148f59f06c4b2bd5db"},
-]
-
-[package.dependencies]
-anyio = ">=3.5.0,<5"
-distro = ">=1.7.0,<2"
-httpx = ">=0.23.0,<1"
-jiter = ">=0.4.0,<1"
-pydantic = ">=1.9.0,<3"
-sniffio = "*"
-tqdm = ">4"
-typing-extensions = ">=4.11,<5"
-
-[package.extras]
-datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
 
 [[package]]
 name = "packaging"
@@ -714,6 +646,20 @@ files = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.1"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
+    {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pytest"
 version = "8.3.3"
 description = "pytest: simple powerful testing with Python"
@@ -826,6 +772,25 @@ files = [
 httpx = ">=0.21.0"
 
 [[package]]
+name = "rich"
+version = "14.0.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0"},
+    {file = "rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -863,27 +828,6 @@ files = [
 ]
 
 [[package]]
-name = "tqdm"
-version = "4.67.0"
-description = "Fast, Extensible Progress Meter"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tqdm-4.67.0-py3-none-any.whl", hash = "sha256:0cd8af9d56911acab92182e88d763100d4788bdf421d251616040cc4d44863be"},
-    {file = "tqdm-4.67.0.tar.gz", hash = "sha256:fe5a6f95e6fe0b9755e9469b77b9c3cf850048224ecaa8293d7d2d31f97d869a"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[package.extras]
-dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
-discord = ["requests"]
-notebook = ["ipywidgets (>=6)"]
-slack = ["slack-sdk"]
-telegram = ["requests"]
-
-[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -917,4 +861,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e173e057327901e3aa1f91c355321404a369646640885557e806e8e63733efbc"
+content-hash = "67df2d2daf0fa6038eca8708ccbac3b6bdf439c94267cc93bd5d55255ef296de"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ pydantic = "^2.9.2"
 typing-extensions = "^4.12.0"
 httpx = ">=0.27.2,<1"
 tenacity = "^9.0.0"
+griffe = "^1.7.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"
@@ -38,6 +39,7 @@ isort = "^5.13.2"
 pre-commit = "^4.0.0"
 python-dotenv = "^1.0.1"
 respx = "^0.21.1"
+rich = "^14.0.0"
 
 
 [tool.black]

--- a/tests/test_schema_conversion.py
+++ b/tests/test_schema_conversion.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+from typing_extensions import TypedDict
+
+from aipolabs import to_json_schema
+from aipolabs.types.functions import FunctionDefinitionFormat
+
+
+class RequiredDict(TypedDict):
+    required_int: int
+    optional_str: str | None
+
+
+class RequiredModel(BaseModel):
+    required_int: int
+    optional_str: str | None
+
+
+class AllowExtraArgs(BaseModel):
+    ...
+    model_config = ConfigDict(extra="allow")
+
+
+EXPECTED_NAME = "my_function"
+EXPECTED_DESCRIPTION = "This is a test function."
+EXPECTED_PARAMETERS = {
+    "properties": {
+        "required_int": {
+            "description": "This is required_int.",
+            "title": "Required Int",
+            "type": "integer",
+        },
+        "required_dict": {
+            "description": "This is required_dict.",
+            "properties": {
+                "required_int": {"title": "Required Int", "type": "integer"},
+                "optional_str": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                    "title": "Optional Str",
+                },
+            },
+            "required": ["required_int", "optional_str"],
+            "title": "RequiredDict",
+            "type": "object",
+            "additionalProperties": False,
+        },
+        "required_model": {
+            "description": "This is required_model.",
+            "properties": {
+                "required_int": {"title": "Required Int", "type": "integer"},
+                "optional_str": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                    "title": "Optional Str",
+                },
+            },
+            "required": ["required_int", "optional_str"],
+            "title": "RequiredModel",
+            "type": "object",
+            "additionalProperties": False,
+        },
+        "allow_extra_args": {
+            "description": "This is allow_extra_args.",
+            "additionalProperties": True,
+            "properties": {},
+            "title": "AllowExtraArgs",
+            "type": "object",
+        },
+        "optional_str_with_default": {
+            "default": "default string",
+            "description": "This is optional_str_with_default.",
+            "title": "Optional Str With Default",
+            "type": "string",
+        },
+    },
+    "required": ["required_int", "required_dict", "required_model", "allow_extra_args"],
+    "title": "my_function_args",
+    "type": "object",
+    "additionalProperties": False,
+}
+
+EXPECTED_JSON_SCHEMA_OPENAI_RESPONSES = {
+    "type": "function",
+    "name": EXPECTED_NAME,
+    "description": EXPECTED_DESCRIPTION,
+    "parameters": EXPECTED_PARAMETERS,
+}
+
+EXPECTED_JSON_SCHEMA_OPENAI = {
+    "type": "function",
+    "function": {
+        "name": EXPECTED_NAME,
+        "description": EXPECTED_DESCRIPTION,
+        "parameters": EXPECTED_PARAMETERS,
+    },
+}
+
+EXPECTED_JSON_SCHEMA_ANTHROPIC = {
+    "name": EXPECTED_NAME,
+    "description": EXPECTED_DESCRIPTION,
+    "input_schema": EXPECTED_PARAMETERS,
+}
+
+
+@pytest.mark.parametrize(
+    ["format", "expected_schema"],
+    [
+        (FunctionDefinitionFormat.OPENAI_RESPONSES, EXPECTED_JSON_SCHEMA_OPENAI_RESPONSES),
+        (FunctionDefinitionFormat.OPENAI, EXPECTED_JSON_SCHEMA_OPENAI),
+        (FunctionDefinitionFormat.ANTHROPIC, EXPECTED_JSON_SCHEMA_ANTHROPIC),
+    ],
+)
+def test_schema_conversion(format: FunctionDefinitionFormat, expected_schema: dict) -> None:
+    # dummy function to test the schema conversion
+    def my_function(
+        required_int: int,
+        required_dict: RequiredDict,
+        required_model: RequiredModel,
+        allow_extra_args: AllowExtraArgs,
+        optional_str_with_default: str = "default string",
+    ) -> None:
+        """This is a test function.
+
+        Args:
+            required_int: This is required_int.
+            required_dict: This is required_dict.
+            required_model: This is required_model.
+            allow_extra_args: This is allow_extra_args.
+            optional_str_with_default: This is optional_str_with_default.
+        """
+        pass
+
+    # test that the schema is generated correctly
+    schema = to_json_schema(my_function, format=format)
+    assert schema == expected_schema


### PR DESCRIPTION
util function to convert a local python function to LLM compatible tool schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functionality to convert Python functions into JSON schemas compatible with multiple LLM tool formats (OpenAI chat completions, OpenAI responses, Anthropic).
  - Introduced automatic extraction of function metadata and docstring documentation to generate detailed parameter schemas.
  - Exposed a new public API for schema conversion.

- **Bug Fixes**
  - Ensured generated JSON schemas are compatible with strict LLM requirements by processing nested and referenced types.

- **Tests**
  - Added comprehensive tests to verify correct schema conversion across supported formats.

- **Chores**
  - Updated dependencies to include support for docstring parsing and improved development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->